### PR TITLE
Fix rate_response_exception

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -55,6 +55,7 @@ class Configuration implements ConfigurationInterface
                             if (! is_subclass_of($item, '\Exception')) {
                                 throw new InvalidConfigurationException(sprintf("'%s' must inherit the \\Exception class", $item));
                             }
+                            return $item;
                         })
                     ->end()
                 ->end()


### PR DESCRIPTION
rate_response_exception currently has no effect due to the validator accidentally replacing it with NULL. Configuration validators have to return the value they're validating due to https://github.com/symfony/Config/blob/master/Definition/BaseNode.php#L309