### PR TITLE
[Security] Prevent ratelimit bypassing by encoding url paths

### DIFF
--- a/Tests/Util/PathLimitProcessorTest.php
+++ b/Tests/Util/PathLimitProcessorTest.php
@@ -49,6 +49,32 @@ class PathLimitProcessorTest extends TestCase
     }
 
     /** @test */
+    function itReturnARateLimitIfItMatchesSubPathWithUrlEncodedString()
+    {
+        $plp = new PathLimitProcessor(array(
+            'api' => array(
+                'path' => 'api',
+                'methods' => array('GET'),
+                'limit' => 100,
+                'period' => 60
+            )
+        ));
+
+        $result = $plp->getRateLimit(
+            Request::create('%2Fapi%2Fusers', 'GET')
+        );
+
+        $this->assertInstanceOf(
+            'Noxlogic\RateLimitBundle\Annotation\RateLimit',
+            $result
+        );
+
+        $this->assertEquals(100, $result->getLimit());
+        $this->assertEquals(60, $result->getPeriod());
+        $this->assertEquals(array('GET'), $result->getMethods());
+    }
+
+    /** @test */
     function itWorksWhenMultipleMethodsAreSpecified()
     {
         $plp = new PathLimitProcessor(array(

--- a/Util/PathLimitProcessor.php
+++ b/Util/PathLimitProcessor.php
@@ -28,7 +28,7 @@ class PathLimitProcessor
 
     public function getRateLimit(Request $request)
     {
-        $path = trim($request->getPathInfo(), '/');
+        $path = trim(urldecode($request->getPathInfo()), '/');
         $method = $request->getMethod();
 
         foreach ($this->pathLimits as $pathLimit) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT

It's possible to bypass the rate limit protection by encoding your path.
This fix decodes the url path before checking it.

