### PR TITLE
Support for Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,38 +5,65 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-
-env:
-    - SYMFONY_VERSION=2.3.*
-    - SYMFONY_VERSION=2.4.*
-    - SYMFONY_VERSION=2.5.*
-    - SYMFONY_VERSION=2.6.*
-    - SYMFONY_VERSION=2.7.*
-    - SYMFONY_VERSION=dev-master
 
 sudo: false
 
 matrix:
+    fast_finish: true
+    include:
+        - php: 5.3
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: 5.4
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: 5.5
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.6.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*
+        - php: 7.0
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: 7.0
+          env: SYMFONY_VERSION=2.3.*
+        - php: 7.0
+          env: SYMFONY_VERSION=2.6.*
+        - php: 7.0
+          env: SYMFONY_VERSION=2.7.*
+        - php: 7.0
+          env: SYMFONY_VERSION=2.8.*
+        - php: 7.0
+          env: SYMFONY_VERSION=3.0.*
+        - php: hhvm
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: hhvm
+          env: SYMFONY_VERSION=2.3.*
+        - php: hhvm
+          env: SYMFONY_VERSION=2.6.*
+        - php: hhvm
+          env: SYMFONY_VERSION=2.7.*
+        - php: hhvm
+          env: SYMFONY_VERSION=2.8.*
+        - php: hhvm
+          env: SYMFONY_VERSION=3.0.*
     allow_failures:
-        - env: SYMFONY_VERSION=2.7.*
+        - env: SYMFONY_VERSION=3.0.*
         - env: SYMFONY_VERSION=dev-master
 
 before_script:
     - wget https://phar.phpunit.de/phpunit-4.1.1.phar
     - composer self-update
-    - composer require symfony/twig-bundle:${SYMFONY_VERSION} --no-update
-    - composer require symfony/twig-bridge:${SYMFONY_VERSION} --no-update
-    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
-    - composer require symfony/validator:${SYMFONY_VERSION} --dev --no-update
-    - composer require symfony/console:${SYMFONY_VERSION} --no-update
-    - composer require symfony/css-selector:${SYMFONY_VERSION} --dev --no-update
-    - composer require symfony/browser-kit:${SYMFONY_VERSION} --dev --no-update
-    - composer require symfony/yaml:${SYMFONY_VERSION} --dev --no-update
-    - composer require symfony/form:${SYMFONY_VERSION} --dev --no-update
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
     - composer require predis/predis:0.8.x --dev --no-update
     - composer require friendsofsymfony/oauth-server-bundle:1.4.x --dev --no-update
-    - composer update
+    - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script: php phpunit-4.1.1.phar --coverage-text --coverage-clover=coverage.clover
 

--- a/DependencyInjection/NoxlogicRateLimitExtension.php
+++ b/DependencyInjection/NoxlogicRateLimitExtension.php
@@ -76,5 +76,15 @@ class NoxlogicRateLimitExtension extends Extension
                 );
                 break;
         }
+
+        // Set the SecurityContext for Symfony < 2.6
+        // Replace with xml when < 2.6 is dropped.
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $tokenStorageReference = new Reference('security.token_storage');
+        } else {
+            $tokenStorageReference = new Reference('security.context');
+        }
+        $container->getDefinition('noxlogic_rate_limit.rate_limit_service')->replaceArgument(0, $tokenStorageReference);
+        $container->getDefinition('noxlogic_rate_limit.oauth_key_generate_listener')->replaceArgument(0, $tokenStorageReference);
     }
 }

--- a/EventListener/OauthKeyGenerateListener.php
+++ b/EventListener/OauthKeyGenerateListener.php
@@ -4,20 +4,21 @@ namespace Noxlogic\RateLimitBundle\EventListener;
 
 use Noxlogic\RateLimitBundle\Events\GenerateKeyEvent;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class OauthKeyGenerateListener
 {
     /**
-     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     * @var SecurityContextInterface|TokenStorageInterface
      */
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
-     * @param SecurityContextInterface $securityContext
+     * @param $tokenStorage
      */
-    public function __construct(SecurityContextInterface $securityContext)
+    public function __construct($tokenStorage)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -25,7 +26,7 @@ class OauthKeyGenerateListener
      */
     public function onGenerateKey(GenerateKeyEvent $event)
     {
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
         if (! $token instanceof \FOS\OAuthServerBundle\Security\Authentication\Token\OAuthToken) {
             return;
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,7 +18,7 @@
         </service>
 
         <service id="noxlogic_rate_limit.rate_limit_service" class="%noxlogic_rate_limit.rate_limit_service.class%">
-            <argument type="service" id="security.context" />
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <call method="setStorage">
                 <argument type="service" id="noxlogic_rate_limit.storage" />
             </call>
@@ -76,7 +76,7 @@
 
 
         <service id="noxlogic_rate_limit.oauth_key_generate_listener" class="%noxlogic_rate_limit.oauth_key_generate_listener.class%">
-            <argument type="service" id="security.context" />
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
 
             <tag name="kernel.event_listener" event="ratelimit.generate.key" method="onGenerateKey" />
         </service>

--- a/Tests/EventListener/OauthKeyGenerateListenerTest.php
+++ b/Tests/EventListener/OauthKeyGenerateListenerTest.php
@@ -9,10 +9,16 @@ use Symfony\Component\HttpFoundation\Request;
 
 class OauthKeyGenerateListenerTest extends TestCase
 {
+    protected $mockContext;
 
     public function setUp() {
         if (! class_exists('FOS\\OAuthServerBundle\\Security\\Authentication\\Token\\OAuthToken')) {
             $this->markTestSkipped('FOSOAuth bundle is not found');
+        }
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $this->mockContext = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        } else {
+            $this->mockContext = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
         }
     }
 
@@ -20,7 +26,7 @@ class OauthKeyGenerateListenerTest extends TestCase
     {
         $mockToken = $this->createMockToken();
 
-        $mockContext = $this->getMock('Symfony\\Component\\Security\\Core\\SecurityContextInterface');
+        $mockContext = $this->mockContext;
         $mockContext
             ->expects($this->any())
             ->method('getToken')
@@ -37,7 +43,7 @@ class OauthKeyGenerateListenerTest extends TestCase
 
     public function testListenerWithoutOAuthToken()
     {
-        $mockContext = $this->getMock('Symfony\\Component\\Security\\Core\\SecurityContextInterface');
+        $mockContext = $this->mockContext;
         $mockContext
             ->expects($this->any())
             ->method('getToken')


### PR DESCRIPTION
SecurityContext was removed in 3.0 - the purpose of this PR is to provide a BC layer for older versions of Symfony.