### PR TITLE
Avoid Sf security dependency and allow more redis clients

### DIFF
--- a/DependencyInjection/NoxlogicRateLimitExtension.php
+++ b/DependencyInjection/NoxlogicRateLimitExtension.php
@@ -77,14 +77,7 @@ class NoxlogicRateLimitExtension extends Extension
                 break;
         }
 
-        // Set the SecurityContext for Symfony < 2.6
-        // Replace with xml when < 2.6 is dropped.
-        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            $tokenStorageReference = new Reference('security.token_storage');
-        } else {
-            $tokenStorageReference = new Reference('security.context');
-        }
-        $container->getDefinition('noxlogic_rate_limit.rate_limit_service')->replaceArgument(0, $tokenStorageReference);
-        $container->getDefinition('noxlogic_rate_limit.oauth_key_generate_listener')->replaceArgument(0, $tokenStorageReference);
+        $container->getDefinition('noxlogic_rate_limit.rate_limit_service')->replaceArgument(0, $$container->getDefinition('noxlogic_rate_limit.storage'));
+        $container->getDefinition('noxlogic_rate_limit.oauth_key_generate_listener')->replaceArgument(0, $$container->getDefinition('noxlogic_rate_limit.storage'));
     }
 }

--- a/Service/Storage/Redis.php
+++ b/Service/Storage/Redis.php
@@ -3,7 +3,6 @@
 namespace Noxlogic\RateLimitBundle\Service\Storage;
 
 use Noxlogic\RateLimitBundle\Service\RateLimitInfo;
-use Predis\Client;
 
 class Redis implements StorageInterface
 {
@@ -12,7 +11,7 @@ class Redis implements StorageInterface
      */
     protected $client;
 
-    public function __construct(Client $client)
+    public function __construct($client)
     {
         $this->client = $client;
     }


### PR DESCRIPTION
Hi,

I do this PR to avoid dependency on Symfony Security Component. And allow phpredisclient, avoiding typehint on redis client.
