### PR TITLE
create services and parameters when not enabled

### DIFF
--- a/DependencyInjection/NoxlogicRateLimitExtension.php
+++ b/DependencyInjection/NoxlogicRateLimitExtension.php
@@ -2,11 +2,11 @@
 
 namespace Noxlogic\RateLimitBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -22,14 +22,14 @@ class NoxlogicRateLimitExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+        $this->loadServices($container, $config);
 
-        if ($config['enabled'] === true) {
-            $this->loadServices($container, $config);
-        }
     }
 
     private function loadServices(ContainerBuilder $container, array $config)
     {
+        $container->setParameter('noxlogic_rate_limit.enabled', $config['enabled']);
+
         $container->setParameter('noxlogic_rate_limit.rate_response_exception', $config['rate_response_exception']);
         $container->setParameter('noxlogic_rate_limit.rate_response_code', $config['rate_response_code']);
         $container->setParameter('noxlogic_rate_limit.rate_response_message', $config['rate_response_message']);
@@ -53,7 +53,7 @@ class NoxlogicRateLimitExtension extends Extension
                 break;
         }
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
         switch ($config['storage_engine']) {

--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -49,6 +49,11 @@ class RateLimitAnnotationListener extends BaseListener
      */
     public function onKernelController(FilterControllerEvent $event)
     {
+        // Skip if the bundle isn't enabled (for instance in test environment)
+        if( ! $this->getParameter('enabled', true)) {
+            return;
+        }
+
         // Skip if we aren't the main request
         if ($event->getRequestType() != HttpKernelInterface::MASTER_REQUEST) {
             return;

--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -95,6 +95,12 @@ class RateLimitAnnotationListener extends BaseListener
         // Reset the rate limits
         if(time() >= $rateLimitInfo->getResetTimestamp()) {
             $this->rateLimitService->resetRate($key);
+            $rateLimitInfo = $this->rateLimitService->createRate($key, $rateLimit->getLimit(), $rateLimit->getPeriod());
+            if (! $rateLimitInfo) {
+                // @codeCoverageIgnoreStart
+                return;
+                // @codeCoverageIgnoreEnd
+            }
         }
 
         // When we exceeded our limit, return a custom error response

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -36,6 +36,10 @@
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" priority="-10" />
 
             <call method="setParameter">
+                <argument>enabled</argument>
+                <argument>%noxlogic_rate_limit.enabled%</argument>
+            </call>
+            <call method="setParameter">
                 <argument>rate_response_code</argument>
                 <argument>%noxlogic_rate_limit.rate_response_code%</argument>
             </call>

--- a/Tests/DependencyInjection/NoxlogicRateLimitExtensionTest.php
+++ b/Tests/DependencyInjection/NoxlogicRateLimitExtensionTest.php
@@ -20,15 +20,13 @@ class NoxlogicRateLimitExtensionTest extends WebTestCase
         $containerBuilder = new ContainerBuilder(new ParameterBag());
         $extension->load(array(), $containerBuilder);
 
+        $this->assertEquals($containerBuilder->getParameter('noxlogic_rate_limit.enabled'), true);
         $this->assertEquals($containerBuilder->getParameter('noxlogic_rate_limit.rate_response_code'), 429);
         $this->assertEquals($containerBuilder->getParameter('noxlogic_rate_limit.display_headers'), true);
         $this->assertEquals($containerBuilder->getParameter('noxlogic_rate_limit.headers.reset.name'), 'X-RateLimit-Reset');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException
-     */
-    public function testNoParametersWhenDisabled()
+    public function testParametersWhenDisabled()
     {
         $extension = new NoxlogicRateLimitExtension();
         $containerBuilder = new ContainerBuilder(new ParameterBag());

--- a/Tests/EventListener/MockStorage.php
+++ b/Tests/EventListener/MockStorage.php
@@ -38,11 +38,6 @@ class MockStorage implements StorageInterface
             return null;
         }
 
-        if ($this->rates[$key]['reset'] <= time()) {
-            unset($this->rates[$key]);
-            return null;
-        }
-
         $this->rates[$key]['calls']++;
         return $this->getRateInfo($key);
     }

--- a/Tests/EventListener/RateLimitAnnotationListenerTest.php
+++ b/Tests/EventListener/RateLimitAnnotationListenerTest.php
@@ -40,6 +40,17 @@ class RateLimitAnnotationListenerTest extends TestCase
     }
 
 
+    public function testReturnedWhenNotEnabled()
+    {
+        $listener = $this->createListener($this->never());
+        $listener->setParameter('enabled', false);
+
+        $event = $this->createEvent();
+
+        $listener->onKernelController($event);
+    }
+
+
     public function testReturnedWhenNotAMasterRequest()
     {
         $listener = $this->createListener($this->never());


### PR DESCRIPTION
To do rate limit checks in other bundles, there could be other services that depend on (for instance) the `RateLimitService`. If `enabled` in the config is set to `false`, these services no longer get created. This PR pushes the check for `enabled` back to the annotation listener.