### PR TITLE
Option to disable fos listener

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -102,6 +102,10 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->booleanNode('fos_oauth_key_listener')
+                    ->defaultTrue()
+                    ->info('Enabled the FOS OAuthServerBundle listener')
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/NoxlogicRateLimitExtension.php
+++ b/DependencyInjection/NoxlogicRateLimitExtension.php
@@ -77,13 +77,17 @@ class NoxlogicRateLimitExtension extends Extension
                 break;
         }
 
-        // Set the SecurityContext for Symfony < 2.6
-        // Replace with xml when < 2.6 is dropped.
-        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            $tokenStorageReference = new Reference('security.token_storage');
+        if ($config['fos_oauth_key_listener']) {
+            // Set the SecurityContext for Symfony < 2.6
+            // Replace with xml when < 2.6 is dropped.
+            if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+                $tokenStorageReference = new Reference('security.token_storage');
+            } else {
+                $tokenStorageReference = new Reference('security.context');
+            }
+            $container->getDefinition('noxlogic_rate_limit.oauth_key_generate_listener')->replaceArgument(0, $tokenStorageReference);
         } else {
-            $tokenStorageReference = new Reference('security.context');
+            $container->removeDefinition('noxlogic_rate_limit.oauth_key_generate_listener');
         }
-        $container->getDefinition('noxlogic_rate_limit.oauth_key_generate_listener')->replaceArgument(0, $tokenStorageReference);
     }
 }

--- a/DependencyInjection/NoxlogicRateLimitExtension.php
+++ b/DependencyInjection/NoxlogicRateLimitExtension.php
@@ -84,7 +84,6 @@ class NoxlogicRateLimitExtension extends Extension
         } else {
             $tokenStorageReference = new Reference('security.context');
         }
-        $container->getDefinition('noxlogic_rate_limit.rate_limit_service')->replaceArgument(0, $tokenStorageReference);
         $container->getDefinition('noxlogic_rate_limit.oauth_key_generate_listener')->replaceArgument(0, $tokenStorageReference);
     }
 }

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ noxlogic_rate_limit:
         
     # - { path: /api, limit: 1000, period: 3600 }
     # - { path: /dashboard, limit: 100, period: 3600, methods: ['GET', 'POST']}
+
+    # Should the FOS OAuthServerBundle listener be enabled 
+    fos_oauth_key_listener: true
 ```
 
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,7 +18,6 @@
         </service>
 
         <service id="noxlogic_rate_limit.rate_limit_service" class="%noxlogic_rate_limit.rate_limit_service.class%">
-            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <call method="setStorage">
                 <argument type="service" id="noxlogic_rate_limit.storage" />
             </call>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -47,7 +47,8 @@ class ConfigurationTest extends WebTestCase
                 'remaining' => 'X-RateLimit-Remaining',
                 'reset' => 'X-RateLimit-Reset',
             ),
-            'path_limits' => array()
+            'path_limits' => array(),
+            'fos_oauth_key_listener' => true
         ), $configuration);
     }
 


### PR DESCRIPTION
I dont use Fos OAuth Bundle, and so want to disable this extra listener running in a performance critical part of my app

Related to what #33 was achieving
