### PR TITLE
remove phpunit dependency on composer.json as it breaks builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "sensio/framework-extra-bundle": ">=2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*"
     },
     "suggest": {
         "snc/redis-bundle": "Use Redis as a storage engine.",


### PR DESCRIPTION
phpunit dependency on composer.json breaks builds with Symfony 3.0 (dependency on symfony/yaml 2.0 breakage).
As phpunit is not used in builds (PHPUnit is downloaded as a standalone), we can safely remove it and have Travis-CI builds fully working.