### PR TITLE
Fix and improve Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,14 +54,13 @@ matrix:
         - env: SYMFONY_VERSION=dev-master       
 
 before_script:
-    - wget https://phar.phpunit.de/phpunit-4.8.9.phar
     - composer self-update
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
     - composer require predis/predis:0.8.x --dev --no-update
     - composer require friendsofsymfony/oauth-server-bundle:1.5.x --dev --no-update
     - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
-script: php phpunit-4.8.9.phar --coverage-text --coverage-clover=coverage.clover
+script: php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ matrix:
           env: SYMFONY_VERSION=2.8.*
         - php: 5.6
           env: SYMFONY_VERSION=3.0.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.1.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.2.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.3.*
         - php: 7.0
           env: COMPOSER_FLAGS="--prefer-lowest"
         - php: 7.0
@@ -38,6 +44,12 @@ matrix:
           env: SYMFONY_VERSION=2.8.*
         - php: 7.0
           env: SYMFONY_VERSION=3.0.*
+        - php: 7.0
+          env: SYMFONY_VERSION=3.1.*
+        - php: 7.0
+          env: SYMFONY_VERSION=3.2.*
+        - php: 7.0
+          env: SYMFONY_VERSION=3.3.*
         - php: 7.1
           env: COMPOSER_FLAGS="--prefer-lowest"
         - php: 7.1
@@ -50,6 +62,12 @@ matrix:
           env: SYMFONY_VERSION=2.8.*
         - php: 7.1
           env: SYMFONY_VERSION=3.0.*
+        - php: 7.1
+          env: SYMFONY_VERSION=3.1.*
+        - php: 7.1
+          env: SYMFONY_VERSION=3.2.*
+        - php: 7.1
+          env: SYMFONY_VERSION=3.3.*
     allow_failures:
         - env: SYMFONY_VERSION=dev-master       
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "sensio/framework-extra-bundle": ">=2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "4.8.*"
     },
     "suggest": {
         "snc/redis-bundle": "Use Redis as a storage engine.",


### PR DESCRIPTION
Builds are failing with Symfony 3.0 because of a failing requirement on symfony/yaml ; 
it is failing because of composer dependency on phpunit 4.1, but this version is not used.

This patch bumps version to PHPUnit 4.8 and use it for Travis builds instead of downloading a new phpunit binary.