### PR TITLE
Force $methods to be an array

### DIFF
--- a/Annotation/RateLimit.php
+++ b/Annotation/RateLimit.php
@@ -75,7 +75,7 @@ class RateLimit extends ConfigurationAnnotation
      */
     public function setMethods($methods)
     {
-        $this->methods = $methods;
+        $this->methods = (array) $methods;
     }
 
     /**

--- a/Tests/Annotation/RateLimitTest.php
+++ b/Tests/Annotation/RateLimitTest.php
@@ -30,7 +30,7 @@ class RateLimitTest extends TestCase
         $annot = new RateLimit(array('methods' => 'POST', 'limit' => 1234, 'period' => 1000));
         $this->assertEquals(1234, $annot->getLimit());
         $this->assertEquals(1000, $annot->getPeriod());
-        $this->assertEquals('POST', $annot->getMethods());
+        $this->assertEquals(['POST'], $annot->getMethods());
     }
 
     public function testConstructionWithMethods()


### PR DESCRIPTION
With PHP7.2, calling count on a non Countable causes a warning.

This bundle calls count() on the RateLimit->getMethods() return value and will fail if it is a string. We had a use in one of our apps where it was a string, which was incorrect, but this brings the methods property on this annotation into the same behaviour as the rest of Symfony's handling of methods.

I was going to make the change where the error occurs (In the RateLimitAnnotationListener), but given the Annotation expects methods to be an array it makes more sense just to force it to be an array.