### PR TITLE
More effecient use of Redis

### DIFF
--- a/Service/Storage/PhpRedis.php
+++ b/Service/Storage/PhpRedis.php
@@ -21,6 +21,9 @@ class PhpRedis implements StorageInterface
     public function getRateInfo($key)
     {
         $info = $this->client->hgetall($key);
+        if (!isset($info['limit']) || !isset($info['calls']) || !isset($info['reset'])) {
+            return false;
+        }
 
         $rateLimitInfo = new RateLimitInfo();
         $rateLimitInfo->setLimit($info['limit']);
@@ -32,23 +35,31 @@ class PhpRedis implements StorageInterface
 
     public function limitRate($key)
     {
-        if (!$this->client->hexists($key, 'limit')) {
+        $info = $this->getRateInfo($key);
+        if (!$info) {
             return false;
         }
 
         $this->client->hincrby($key, 'calls', 1);
 
-        return $this->getRateInfo($key);
+        return $info;
     }
 
     public function createRate($key, $limit, $period)
     {
+        $reset = time() + $period;
+
         $this->client->hset($key, 'limit', $limit);
         $this->client->hset($key, 'calls', 1);
-        $this->client->hset($key, 'reset', time() + $period);
+        $this->client->hset($key, 'reset', $reset);
         $this->client->expire($key, $period);
 
-        return $this->getRateInfo($key);
+        $rateLimitInfo = new RateLimitInfo();
+        $rateLimitInfo->setLimit($limit);
+        $rateLimitInfo->setCalls(1);
+        $rateLimitInfo->setResetTimestamp($reset);
+
+        return $rateLimitInfo;
     }
 
     public function resetRate($key)

--- a/Service/Storage/Redis.php
+++ b/Service/Storage/Redis.php
@@ -20,6 +20,9 @@ class Redis implements StorageInterface
     public function getRateInfo($key)
     {
         $info = $this->client->hgetall($key);
+        if (!isset($info['limit']) || !isset($info['calls']) || !isset($info['reset'])) {
+            return false;
+        }
 
         $rateLimitInfo = new RateLimitInfo();
         $rateLimitInfo->setLimit($info['limit']);
@@ -31,28 +34,38 @@ class Redis implements StorageInterface
 
     public function limitRate($key)
     {
-        if (! $this->client->hexists($key, 'limit')) {
+        $info = $this->getRateInfo($key);
+        if (!$info) {
             return false;
         }
 
         $this->client->hincrby($key, 'calls', 1);
 
-        return $this->getRateInfo($key);
+        return $info;
     }
 
     public function createRate($key, $limit, $period)
     {
+        $reset = time() + $period;
+
         $this->client->hset($key, 'limit', $limit);
         $this->client->hset($key, 'calls', 1);
-        $this->client->hset($key, 'reset', time() + $period);
+        $this->client->hset($key, 'reset', $reset);
         $this->client->expire($key, $period);
 
-        return $this->getRateInfo($key);
+        $rateLimitInfo = new RateLimitInfo();
+        $rateLimitInfo->setLimit($limit);
+        $rateLimitInfo->setCalls(1);
+        $rateLimitInfo->setResetTimestamp($reset);
+
+        return $rateLimitInfo;
     }
 
     public function resetRate($key)
     {
-        $this->client->hdel($key);
+        $this->client->del($key);
+
         return true;
     }
+
 }

--- a/Tests/Service/Storage/PhpRedisTest.php
+++ b/Tests/Service/Storage/PhpRedisTest.php
@@ -52,11 +52,11 @@ class PhpRedisTest extends TestCase
 
     public function testLimitRateNoKey()
     {
-        $client = $this->getMock('\Redis', array('hexists'));
+        $client = $this->getMock('\Redis', array('hgetall'));
         $client->expects($this->once())
-              ->method('hexists')
-              ->with('foo', 'limit')
-              ->will($this->returnValue(false));
+              ->method('hgetall')
+              ->with('foo')
+              ->will($this->returnValue([]));
 
         $storage = new PhpRedis($client);
         $this->assertFalse($storage->limitRate('foo'));
@@ -64,15 +64,19 @@ class PhpRedisTest extends TestCase
 
     public function testLimitRateWithKey()
     {
-        $client = $this->getMock('\Redis', array('hexists', 'hincrby', 'hgetall'));
+        $client = $this->getMock('\Redis', array('hincrby', 'hgetall'));
         $client->expects($this->once())
-              ->method('hexists')
-              ->with('foo', 'limit')
-              ->will($this->returnValue(true));
+              ->method('hgetall')
+              ->with('foo')
+              ->will($this->returnValue([
+                  'limit' => 1,
+                  'calls' => 1,
+                  'reset' => 1,
+              ]));
         $client->expects($this->once())
               ->method('hincrby')
               ->with('foo', 'calls', 1)
-              ->will($this->returnValue(true));
+              ->will($this->returnValue(2));
 
         $storage = new PhpRedis($client);
         $storage->limitRate('foo');


### PR DESCRIPTION
Goes on top of #51 so its really just one commit

- Avoid using hexists and hgetall when just one call can be used
- Avoid using hgetall after hset when we know the values
- Fix reset rate, hdel expects field name(s), del will delete the whole value
