### PR TITLE
[BigFix] allow use sensio/framework-extra-bundle 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_script:
     - composer self-update
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
     - composer require predis/predis:0.8.x --dev --no-update
-    - composer require friendsofsymfony/oauth-server-bundle:1.5.x --dev --no-update
+    - if [[ "$SYMFONY_VERSION" = "4."* ]]; then composer require friendsofsymfony/oauth-server-bundle:1.6.x --dev --no-update; else composer require friendsofsymfony/oauth-server-bundle:1.5.x --dev --no-update; fi
     - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script: php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
 
 before_install:
     - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-
+    - echo "memory_limit = 2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 before_script:
     - composer self-update
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "^2.3|^3.0|^4.0",
-        "sensio/framework-extra-bundle": "^2.3|^3.0|^4.0"
+        "sensio/framework-extra-bundle": "^2.3|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0"


### PR DESCRIPTION
sensio/framework-extra-bundle does not follow the symfony release cycle. The latest version is 5.x 
(see https://github.com/sensiolabs/SensioFrameworkExtraBundle/releases

From the list it looks the 4.0 was somehow skipped