### PR TITLE
Add extra payload to annotation

### DIFF
--- a/Annotation/RateLimit.php
+++ b/Annotation/RateLimit.php
@@ -27,6 +27,11 @@ class RateLimit extends ConfigurationAnnotation
     protected $period = 3600;
 
     /**
+     * @var mixed Generic payload
+     */
+    protected $payload;
+
+    /**
      * Returns the alias name for an annotated configuration.
      *
      * @return string
@@ -93,4 +98,21 @@ class RateLimit extends ConfigurationAnnotation
     {
         $this->period = $period;
     }
+
+    /**
+     * @return mixed
+     */
+    public function getPayload()
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @param mixed $payload
+     */
+    public function setPayload($payload)
+    {
+        $this->payload = $payload;
+    }
+
 }

--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -6,6 +6,7 @@ use Noxlogic\RateLimitBundle\Annotation\RateLimit;
 use Noxlogic\RateLimitBundle\Events\CheckedRateLimitEvent;
 use Noxlogic\RateLimitBundle\Events\GenerateKeyEvent;
 use Noxlogic\RateLimitBundle\Events\RateLimitEvents;
+use Noxlogic\RateLimitBundle\Exception\RateLimitExceptionInterface;
 use Noxlogic\RateLimitBundle\Service\RateLimitService;
 use Noxlogic\RateLimitBundle\Util\PathLimitProcessor;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -111,7 +112,14 @@ class RateLimitAnnotationListener extends BaseListener
             // Throw an exception if configured.
             if ($this->getParameter('rate_response_exception')) {
                 $class = $this->getParameter('rate_response_exception');
-                throw new $class($this->getParameter('rate_response_message'), $this->getParameter('rate_response_code'));
+
+                $e = new $class($this->getParameter('rate_response_message'), $this->getParameter('rate_response_code'));
+
+                if ($e instanceof RateLimitExceptionInterface) {
+                    $e->setPayload($rateLimit->getPayload());
+                }
+
+                throw $e;
             }
 
             $message = $this->getParameter('rate_response_message');

--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -166,7 +166,7 @@ class RateLimitAnnotationListener extends BaseListener
     private function getKey(FilterControllerEvent $event, RateLimit $rateLimit, array $annotations)
     {
         // Let listeners manipulate the key
-        $keyEvent = new GenerateKeyEvent($event->getRequest());
+        $keyEvent = new GenerateKeyEvent($event->getRequest(), '', $rateLimit->getPayload());
 
         $rateLimitMethods = join('.', $rateLimit->getMethods());
         $keyEvent->addToKey($rateLimitMethods);

--- a/Events/GenerateKeyEvent.php
+++ b/Events/GenerateKeyEvent.php
@@ -14,10 +14,14 @@ class GenerateKeyEvent extends Event
     /** @var string */
     protected $key;
 
-    public function __construct(Request $request, $key = '')
+    /** @var mixed */
+    protected $payload;
+
+    public function __construct(Request $request, $key = '', $payload = null)
     {
         $this->request = $request;
         $this->key = $key;
+        $this->payload = $payload;
     }
 
     /**
@@ -54,5 +58,13 @@ class GenerateKeyEvent extends Event
         } else {
             $this->key = $part;
         }
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPayload()
+    {
+        return $this->payload;
     }
 }

--- a/Exception/RateLimitExceptionInterface.php
+++ b/Exception/RateLimitExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Noxlogic\RateLimitBundle\Exception;
+
+interface RateLimitExceptionInterface
+{
+    /**
+     * @param mixed $payload
+     * @return void
+     */
+    public function setPayload($payload);
+}

--- a/Tests/Events/GenerateKeyEventsTest.php
+++ b/Tests/Events/GenerateKeyEventsTest.php
@@ -25,6 +25,14 @@ class GenerateKeyEventsTest extends TestCase
         $this->assertEquals($request, $event->getRequest());
     }
 
+    public function testPayload()
+    {
+        $request = new Request();
+        $event = new GenerateKeyEvent($request, "", 'bar');
+
+        $this->assertSame('bar', $event->getPayload());
+    }
+
     public function testAddKey()
     {
         $request = new Request();

--- a/Tests/Exception/TestException.php
+++ b/Tests/Exception/TestException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Noxlogic\RateLimitBundle\Tests\Exception;
+
+use Noxlogic\RateLimitBundle\Exception\RateLimitExceptionInterface;
+
+class TestException extends \Exception implements RateLimitExceptionInterface
+{
+    public $payload;
+
+    public function setPayload($payload)
+    {
+        $this->payload = $payload;
+    }
+}


### PR DESCRIPTION
This allows writing custom rules for specific rate limits (key generation or exception handling)

In my case used to render a custom exception message for some rate limits

The idea is similar to the symfony/validator payload property (see https://symfony.com/doc/current/validation/severity.html#assigning-the-error-level)