### PR TITLE
Redis storage engine bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.15.0
+2020-02-10 jaytaph
+- Added support for Symfony 5.x and removed support for < 3.4 and < 4.3 (kai)
+- Dropped support for PHP 7.2 or lower
+
 ## 1.14.0
 2019-02-19 goetas
 - Added Payload to RateLimit to allow better exceptions

--- a/DependencyInjection/NoxlogicRateLimitExtension.php
+++ b/DependencyInjection/NoxlogicRateLimitExtension.php
@@ -59,10 +59,10 @@ class NoxlogicRateLimitExtension extends Extension
                 break;
             case 'redis':
                 $container->setParameter('noxlogic_rate_limit.storage.class', 'Noxlogic\RateLimitBundle\Service\Storage\Redis');
-                if (isset($config['redis_client'])) {
-                    $service = 'snc_redis.' . $config['redis_client'];
-                } else {
+                if (isset($config['redis_service'])) {
                     $service = $config['redis_service'];
+                } else {
+                    $service = 'snc_redis.' . $config['redis_client'];
                 }
                 $container->getDefinition('noxlogic_rate_limit.storage')->replaceArgument(
                     0,

--- a/Service/Storage/Redis.php
+++ b/Service/Storage/Redis.php
@@ -3,16 +3,16 @@
 namespace Noxlogic\RateLimitBundle\Service\Storage;
 
 use Noxlogic\RateLimitBundle\Service\RateLimitInfo;
-use Predis\Client;
+use Predis\ClientInterface;
 
 class Redis implements StorageInterface
 {
     /**
-     * @var \Predis\Client
+     * @var \Predis\ClientInterface
      */
     protected $client;
 
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->client = $client;
     }


### PR DESCRIPTION
This PR solves two small problems I'm currently having with the bundle:

1. We're using the predis `Client` implementation instead of the `ClientInterface`, which means you cannot inject your own custom clients (in my case, I need to proxy something).

2. Using a custom (non-snc_redis) service was not possible, because `snc_predis.default_client` would always have priority. This is changed so we can actually use our custom service.