### PR TITLE
Fix Symfony 4.3 deprecations without breaking BC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:

--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Route;
 
 class RateLimitAnnotationListener extends BaseListener

--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -70,7 +70,9 @@ class RateLimitAnnotationListener extends BaseListener
         // Another treatment before applying RateLimit ?
         $checkedRateLimitEvent = new CheckedRateLimitEvent($event->getRequest(), $rateLimit);
         if(Kernel::VERSION_ID >= 40300) {
+            // Support for symfony listeners which are using the old event name.
             $this->eventDispatcher->dispatch($checkedRateLimitEvent, RateLimitEvents::CHECKED_RATE_LIMIT);
+            $this->eventDispatcher->dispatch($checkedRateLimitEvent);
         } else {
             $this->eventDispatcher->dispatch(RateLimitEvents::CHECKED_RATE_LIMIT, $checkedRateLimitEvent);
         }
@@ -180,8 +182,13 @@ class RateLimitAnnotationListener extends BaseListener
             ? str_replace('/', '.', $this->pathLimitProcessor->getMatchedPath($event->getRequest()))
             : $this->getAliasForRequest($event);
         $keyEvent->addToKey($rateLimitAlias);
-
-        $this->eventDispatcher->dispatch(RateLimitEvents::GENERATE_KEY, $keyEvent);
+        if(Kernel::VERSION_ID >= 40300) {
+            // Support for symfony listeners which are using the old event name.
+            $this->eventDispatcher->dispatch($keyEvent, RateLimitEvents::GENERATE_KEY);
+            $this->eventDispatcher->dispatch($keyEvent);
+        } else {
+            $this->eventDispatcher->dispatch(RateLimitEvents::GENERATE_KEY, $keyEvent);
+        }
 
         return $keyEvent->getKey();
     }

--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -68,7 +68,11 @@ class RateLimitAnnotationListener extends BaseListener
 
         // Another treatment before applying RateLimit ?
         $checkedRateLimitEvent = new CheckedRateLimitEvent($event->getRequest(), $rateLimit);
-        $this->eventDispatcher->dispatch(RateLimitEvents::CHECKED_RATE_LIMIT, $checkedRateLimitEvent);
+        if(Kernel::VERSION_ID >= 40300) {
+            $this->eventDispatcher->dispatch($checkedRateLimitEvent, RateLimitEvents::CHECKED_RATE_LIMIT);
+        } else {
+            $this->eventDispatcher->dispatch(RateLimitEvents::CHECKED_RATE_LIMIT, $checkedRateLimitEvent);
+        }
         $rateLimit = $checkedRateLimitEvent->getRateLimit();
 
         // No matching annotation found

--- a/Events/CheckedRateLimitEvent.php
+++ b/Events/CheckedRateLimitEvent.php
@@ -3,49 +3,97 @@
 namespace Noxlogic\RateLimitBundle\Events;
 
 use Noxlogic\RateLimitBundle\Annotation\RateLimit;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+use Symfony\Component\EventDispatcher\Event as ComponentEvent;
 use Symfony\Component\HttpFoundation\Request;
 
-class CheckedRateLimitEvent extends Event
-{
-
-    /**
-     * @var Request
-     */
-    protected $request;
-
-    /**
-     * @var RateLimit|null
-     */
-    protected $rateLimit;
-
-    public function __construct(Request $request, RateLimit $rateLimit = null)
+if(Kernel::VERSION_ID >= 40300) {
+    class CheckedRateLimitEvent extends ContractsEvent
     {
-        $this->request = $request;
-        $this->rateLimit = $rateLimit;
+
+        /**
+         * @var Request
+         */
+        protected $request;
+
+        /**
+         * @var RateLimit|null
+         */
+        protected $rateLimit;
+
+        public function __construct(Request $request, RateLimit $rateLimit = null)
+        {
+            $this->request = $request;
+            $this->rateLimit = $rateLimit;
+        }
+
+        /**
+         * @return RateLimit|null
+         */
+        public function getRateLimit()
+        {
+            return $this->rateLimit;
+        }
+
+        /**
+         * @param RateLimit|null $rateLimit
+         */
+        public function setRateLimit(RateLimit $rateLimit = null)
+        {
+            $this->rateLimit = $rateLimit;
+        }
+
+        /**
+         * @return Request
+         */
+        public function getRequest()
+        {
+            return $this->request;
+        }
     }
-
-    /**
-     * @return RateLimit|null
-     */
-    public function getRateLimit()
+} else {
+    class CheckedRateLimitEvent extends ComponentEvent
     {
-        return $this->rateLimit;
-    }
 
-    /**
-     * @param RateLimit|null $rateLimit
-     */
-    public function setRateLimit(RateLimit $rateLimit = null)
-    {
-        $this->rateLimit = $rateLimit;
-    }
+        /**
+         * @var Request
+         */
+        protected $request;
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
-    {
-        return $this->request;
+        /**
+         * @var RateLimit|null
+         */
+        protected $rateLimit;
+
+        public function __construct(Request $request, RateLimit $rateLimit = null)
+        {
+            $this->request = $request;
+            $this->rateLimit = $rateLimit;
+        }
+
+        /**
+         * @return RateLimit|null
+         */
+        public function getRateLimit()
+        {
+            return $this->rateLimit;
+        }
+
+        /**
+         * @param RateLimit|null $rateLimit
+         */
+        public function setRateLimit(RateLimit $rateLimit = null)
+        {
+            $this->rateLimit = $rateLimit;
+        }
+
+        /**
+         * @return Request
+         */
+        public function getRequest()
+        {
+            return $this->request;
+        }
     }
 }

--- a/Events/GenerateKeyEvent.php
+++ b/Events/GenerateKeyEvent.php
@@ -2,69 +2,137 @@
 
 namespace Noxlogic\RateLimitBundle\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+use Symfony\Component\EventDispatcher\Event as ComponentEvent;
 use Symfony\Component\HttpFoundation\Request;
 
-class GenerateKeyEvent extends Event
-{
-
-    /** @var Request */
-    protected $request;
-
-    /** @var string */
-    protected $key;
-
-    /** @var mixed */
-    protected $payload;
-
-    public function __construct(Request $request, $key = '', $payload = null)
+if(Kernel::VERSION_ID >= 40300) {
+    class GenerateKeyEvent extends ContractsEvent
     {
-        $this->request = $request;
-        $this->key = $key;
-        $this->payload = $payload;
-    }
 
-    /**
-     * @return string
-     */
-    public function getKey()
-    {
-        return $this->key;
-    }
+        /** @var Request */
+        protected $request;
 
-    /**
-     * @param string $key
-     */
-    public function setKey($key)
-    {
-        $this->key = $key;
-    }
+        /** @var string */
+        protected $key;
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
-    {
-        return $this->request;
-    }
+        /** @var mixed */
+        protected $payload;
 
-    /**
-     * @param $part
-     */
-    public function addToKey($part)
-    {
-        if ($this->key) {
-            $this->key .= '.'.$part;
-        } else {
-            $this->key = $part;
+        public function __construct(Request $request, $key = '', $payload = null)
+        {
+            $this->request = $request;
+            $this->key = $key;
+            $this->payload = $payload;
+        }
+
+        /**
+         * @return string
+         */
+        public function getKey()
+        {
+            return $this->key;
+        }
+
+        /**
+         * @param string $key
+         */
+        public function setKey($key)
+        {
+            $this->key = $key;
+        }
+
+        /**
+         * @return Request
+         */
+        public function getRequest()
+        {
+            return $this->request;
+        }
+
+        /**
+         * @param $part
+         */
+        public function addToKey($part)
+        {
+            if ($this->key) {
+                $this->key .= '.' . $part;
+            } else {
+                $this->key = $part;
+            }
+        }
+
+        /**
+         * @return mixed
+         */
+        public function getPayload()
+        {
+            return $this->payload;
         }
     }
-
-    /**
-     * @return mixed
-     */
-    public function getPayload()
+} else {
+    class GenerateKeyEvent extends ComponentEvent
     {
-        return $this->payload;
-    }
+
+        /** @var Request */
+        protected $request;
+
+        /** @var string */
+        protected $key;
+
+        /** @var mixed */
+        protected $payload;
+
+        public function __construct(Request $request, $key = '', $payload = null)
+        {
+            $this->request = $request;
+            $this->key = $key;
+            $this->payload = $payload;
+        }
+
+        /**
+         * @return string
+         */
+        public function getKey()
+        {
+            return $this->key;
+        }
+
+        /**
+         * @param string $key
+         */
+        public function setKey($key)
+        {
+            $this->key = $key;
+        }
+
+        /**
+         * @return Request
+         */
+        public function getRequest()
+        {
+            return $this->request;
+        }
+
+        /**
+         * @param $part
+         */
+        public function addToKey($part)
+        {
+            if ($this->key) {
+                $this->key .= '.' . $part;
+            } else {
+                $this->key = $part;
+            }
+        }
+
+        /**
+         * @return mixed
+         */
+        public function getPayload()
+        {
+            return $this->payload;
+        }
+    }    
 }

--- a/Tests/EventListener/RateLimitAnnotationListenerTest.php
+++ b/Tests/EventListener/RateLimitAnnotationListenerTest.php
@@ -4,7 +4,6 @@ namespace Noxlogic\RateLimitBundle\EventListener\Tests;
 
 use Noxlogic\RateLimitBundle\Annotation\RateLimit;
 use Noxlogic\RateLimitBundle\EventListener\RateLimitAnnotationListener;
-use Noxlogic\RateLimitBundle\Events\GenerateKeyEvent;
 use Noxlogic\RateLimitBundle\Events\RateLimitEvents;
 use Noxlogic\RateLimitBundle\Service\RateLimitService;
 use Noxlogic\RateLimitBundle\Tests\EventListener\MockStorage;
@@ -391,11 +390,11 @@ class RateLimitAnnotationListenerTest extends TestCase
                         $this->assertSame('Noxlogic.RateLimitBundle.EventListener.Tests.MockController.mockAction', $event->getKey());
                     } else {
                         $event = $name;
-                        if (get_class($event) !== GenerateKeyEvent::class) {
+                        if (get_class($event) !== 'Noxlogic\RateLimitBundle\Events\GenerateKeyEvent') {
                             return;
                         }
                         $generated = true;
-                        $this->assertSame(GenerateKeyEvent::class, get_class($event));
+                        $this->assertSame('Noxlogic\RateLimitBundle\Events\GenerateKeyEvent', get_class($event));
                         $this->assertSame($request, $event->getRequest());
                         $this->assertSame(['foo'], $event->getPayload());
                         $this->assertSame('Noxlogic.RateLimitBundle.EventListener.Tests.MockController.mockAction', $event->getKey());

--- a/Tests/EventListener/RateLimitAnnotationListenerTest.php
+++ b/Tests/EventListener/RateLimitAnnotationListenerTest.php
@@ -376,7 +376,7 @@ class RateLimitAnnotationListenerTest extends TestCase
             ->method('dispatch')
             ->willReturnCallback(function ($name, $event = null) use ($request, &$generated) {
                 if(Kernel::VERSION_ID >= 40300) {
-                    if(!is_null(event)) {
+                    if(!is_null($event)) {
                         // Used if old Event names are used instead of the event object
                         $swap = $name;
                         $name = $event;

--- a/Tests/EventListener/RateLimitAnnotationListenerTest.php
+++ b/Tests/EventListener/RateLimitAnnotationListenerTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class MockController {
     function mockAction() { }
@@ -67,7 +68,11 @@ class RateLimitAnnotationListenerTest extends TestCase
 
     public function testReturnedWhenNoControllerFound()
     {
-        $listener = $this->createListener($this->once());
+        if(Kernel::VERSION_ID >= 40300) {
+            $listener = $this->createListener($this->exactly(2));
+        } else {
+            $listener = $this->createListener($this->once());
+        }
 
         $kernel = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\HttpKernelInterface')->getMock();
         $request = new Request();
@@ -79,7 +84,11 @@ class RateLimitAnnotationListenerTest extends TestCase
 
     public function testReturnedWhenNoAnnotationsFound()
     {
-        $listener = $this->createListener($this->once());
+        if(Kernel::VERSION_ID >= 40300) {
+            $listener = $this->createListener($this->exactly(2));
+        } else {
+            $listener = $this->createListener($this->once());
+        }
 
         $event = $this->createEvent();
         $listener->onKernelController($event);
@@ -90,7 +99,11 @@ class RateLimitAnnotationListenerTest extends TestCase
         $request = new Request();
         $event = $this->createEvent(HttpKernelInterface::MASTER_REQUEST, $request);
 
-        $listener = $this->createListener($this->once());
+        if(Kernel::VERSION_ID >= 40300) {
+            $listener = $this->createListener($this->exactly(2));
+        } else {
+            $listener = $this->createListener($this->once());
+        }
 
         $this->mockPathLimitProcessor->expects($this->once())
                                      ->method('getRateLimit')
@@ -101,7 +114,11 @@ class RateLimitAnnotationListenerTest extends TestCase
 
     public function testDispatchIsCalled()
     {
-        $listener = $this->createListener($this->exactly(2));
+        if(Kernel::VERSION_ID >= 40300) {
+            $listener = $this->createListener($this->exactly(4));
+        } else {
+            $listener = $this->createListener($this->exactly(2));
+        }
 
         $event = $this->createEvent();
         $event->getRequest()->attributes->set('_x-rate-limit', array(
@@ -115,7 +132,11 @@ class RateLimitAnnotationListenerTest extends TestCase
     {
         $event = $this->createEvent(HttpKernelInterface::MASTER_REQUEST);
 
-        $listener = $this->createListener($this->exactly(2));
+        if(Kernel::VERSION_ID >= 40300) {
+            $listener = $this->createListener($this->exactly(4));
+        } else {
+            $listener = $this->createListener($this->exactly(2));
+        }
 
         $rateLimit = new RateLimit(array(
             'limit' => 100,


### PR DESCRIPTION
I guess that's the only way to fix the deprecations since symfony 4.3 and don't break the BC at the same time..