### PR TITLE
Added RedisCluster functionality

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
             ->canBeDisabled()
             ->children()
                 ->enumNode('storage_engine')
-                    ->values(array('redis','memcache','doctrine', 'php_redis', 'simple_cache', 'cache'))
+                    ->values(array('redis','memcache','doctrine', 'php_redis', 'php_redis_cluster', 'simple_cache', 'cache'))
                     ->defaultValue('redis')
                     ->info('The storage engine where all the rates will be stored')
                 ->end()

--- a/DependencyInjection/NoxlogicRateLimitExtension.php
+++ b/DependencyInjection/NoxlogicRateLimitExtension.php
@@ -88,6 +88,13 @@ class NoxlogicRateLimitExtension extends Extension
                     new Reference($config['php_redis_service'])
                 );
                 break;
+            case 'php_redis_cluster':
+                $container->setParameter('noxlogic_rate_limit.storage.class', 'Noxlogic\RateLimitBundle\Service\Storage\PhpRedisCluster');
+                $container->getDefinition('noxlogic_rate_limit.storage')->replaceArgument(
+                    0,
+                    new Reference($config['php_redis_service'])
+                );
+                break;
             case 'simple_cache':
                 $container->setParameter('noxlogic_rate_limit.storage.class', 'Noxlogic\RateLimitBundle\Service\Storage\SimpleCache');
                 $container->getDefinition('noxlogic_rate_limit.storage')->replaceArgument(

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ noxlogic_rate_limit:
     redis_service:    null # Example: project.predis
 
     # The Redis client to use for the php_redis storage engine
-    # Should be an instance of \Redis
+    # Depending on storage_engine an instance of \Redis or \RedisCluster
     php_redis_service:    null # Example: project.redis
 
     # The memcache client to use for the memcache storage engine

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ noxlogic_rate_limit:
     enabled:              true
 
     # The storage engine where all the rates will be stored
-    storage_engine:       ~ # One of "redis"; "memcache"; "doctrine"; "php_redis"
+    storage_engine:       ~ # One of "redis"; "memcache"; "doctrine"; "php_redis"; "php_redis_cluster"
 
     # The redis client to use for the redis storage engine
     redis_client:         default_client

--- a/Service/Storage/PhpRedisCluster.php
+++ b/Service/Storage/PhpRedisCluster.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Noxlogic\RateLimitBundle\Service\Storage;
+
+
+class PhpRedisCluster extends PhpRedis
+{
+
+    public function __construct(\RedisCluster $client)
+    {
+        $this->client = $client;
+    }
+
+}

--- a/Tests/Service/Storage/PhpRedisClusterTest.php
+++ b/Tests/Service/Storage/PhpRedisClusterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Noxlogic\RateLimitBundle\Tests\Service\Storage;
+
+
+use Noxlogic\RateLimitBundle\Service\Storage\PhpRedisCluster;
+
+class PhpRedisClusterTest extends PhpRedisTest
+{
+    public function setUp(): void {
+        if (! class_exists('\RedisCluster')) {
+            $this->markTestSkipped('Php Redis client not installed');
+        }
+    }
+
+    protected function getRedisMock() {
+        return $this->getMockBuilder('\RedisCluster')->disableOriginalConstructor();
+    }
+
+    protected function getStorage($client) {
+        return new PhpRedisCluster($client);
+    }
+}

--- a/Tests/Service/Storage/PhpRedisTest.php
+++ b/Tests/Service/Storage/PhpRedisTest.php
@@ -13,10 +13,18 @@ class PhpRedisTest extends TestCase
             $this->markTestSkipped('Php Redis client not installed');
         }
     }
+    
+    protected function getRedisMock() {
+        return $this->getMockBuilder('\Redis');
+    }
+
+    protected function getStorage($client) {
+        return new PhpRedis($client);
+    }
 
     public function testgetRateInfo()
     {
-        $client = $this->getMockBuilder('\Redis')
+        $client = $this->getRedisMock()
             ->setMethods(array('hgetall'))
             ->getMock();
         $client->expects($this->once())
@@ -24,7 +32,7 @@ class PhpRedisTest extends TestCase
               ->with('foo')
               ->will($this->returnValue(array('limit' => 100, 'calls' => 50, 'reset' => 1234)));
 
-        $storage = new PhpRedis($client);
+        $storage = $this->getStorage($client);
         $rli = $storage->getRateInfo('foo');
         $this->assertInstanceOf('Noxlogic\\RateLimitBundle\\Service\\RateLimitInfo', $rli);
         $this->assertEquals(100, $rli->getLimit());
@@ -34,7 +42,7 @@ class PhpRedisTest extends TestCase
 
     public function testcreateRate()
     {
-        $client = $this->getMockBuilder('\Redis')
+        $client = $this->getRedisMock()
             ->setMethods(array('hset', 'expire', 'hgetall'))
             ->getMock();
         $client->expects($this->once())
@@ -48,14 +56,14 @@ class PhpRedisTest extends TestCase
                     array('foo', 'reset')
               );
 
-        $storage = new PhpRedis($client);
+        $storage = $this->getStorage($client);
         $storage->createRate('foo', 100, 123);
     }
 
 
     public function testLimitRateNoKey()
     {
-        $client = $this->getMockBuilder('\Redis')
+        $client = $this->getRedisMock()
             ->setMethods(array('hgetall'))
             ->getMock();
         $client->expects($this->once())
@@ -63,13 +71,13 @@ class PhpRedisTest extends TestCase
               ->with('foo')
               ->will($this->returnValue([]));
 
-        $storage = new PhpRedis($client);
+        $storage = $this->getStorage($client);
         $this->assertFalse($storage->limitRate('foo'));
     }
 
     public function testLimitRateWithKey()
     {
-        $client = $this->getMockBuilder('\Redis')
+        $client = $this->getRedisMock()
             ->setMethods(array('hincrby', 'hgetall'))
             ->getMock();
         $client->expects($this->once())
@@ -85,7 +93,7 @@ class PhpRedisTest extends TestCase
               ->with('foo', 'calls', 1)
               ->will($this->returnValue(2));
 
-        $storage = new PhpRedis($client);
+        $storage = $this->getStorage($client);
         $storage->limitRate('foo');
     }
 
@@ -93,14 +101,14 @@ class PhpRedisTest extends TestCase
 
     public function testresetRate()
     {
-        $client = $this->getMockBuilder('\Redis')
+        $client = $this->getRedisMock()
             ->setMethods(array('del'))
             ->getMock();
         $client->expects($this->once())
               ->method('del')
               ->with('foo');
 
-        $storage = new PhpRedis($client);
+        $storage = $this->getStorage($client);
         $this->assertTrue($storage->resetRate('foo'));
     }
 


### PR DESCRIPTION
This PR adds the functionality to work with RedisCluster.
Cause \RedisCluster doesn't extend \Redis as Predis does, it's not possible to use the RateLimitBundle in a cluster setting with PhpRedis.
At least it's like Predis and all commands work on the cluster, too.