### PR TITLE
Allow to ignore ratelimits

### DIFF
--- a/EventListener/RateLimitAnnotationListener.php
+++ b/EventListener/RateLimitAnnotationListener.php
@@ -78,6 +78,11 @@ class RateLimitAnnotationListener extends BaseListener
         }
 
         $key = $this->getKey($event, $rateLimit, $annotations);
+        
+        // Skip if falsey key is returned
+        if (! $key) {
+            return;
+        }
 
         // Ratelimit the call
         $rateLimitInfo = $this->rateLimitService->limitRate($key);


### PR DESCRIPTION
With this change we can allow to skip ratelimits under certain conditions. For example, when creating the key you can check if the client's ip is in a special whitelist and ignore their ratelimit, or if the logged in user is and admin, or whatever special case you need.