### PR TITLE
Remove a deprecation on symfony 5.4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('noxlogic_rate_limit');
         // Keep compatibility with symfony/config < 4.2


### PR DESCRIPTION
This remove the following deprecation on sf 5.4
`
Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Noxlogic\RateLimitBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message. `