### PR TITLE
Simple phpunit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ "7.2", "7.3", "7.4", "8.0", "8.1" ]
+                php: [ "7.2", "7.3", "7.4", "8.0", "8.1", "8.2" ]
                 composer_flags: [ "", "--prefer-lowest" ]
-                symfony_version: [ "^3.4", "^4.4", "^5.4", '^6.1']
+                symfony_version: [ "^3.4", "^4.4", "^5.4", "^6.3"]
                 exclude:
-#                  - php: "8.0"
-#                    symfony_version: "^3.4"
-
                   - php: "7.2"
-                    symfony_version: "^6.1"
+                    symfony_version: "^6.3"
                   - php: "7.3"
-                    symfony_version: "^6.1"
+                    symfony_version: "^6.3"
                   - php: "7.4"
-                    symfony_version: "^6.1"
+                    symfony_version: "^6.3"
                   - php: "8.0"
-                    symfony_version: "^6.1"
+                    symfony_version: "^6.3"
+                  - php: "8.2"
+                    symfony_version: "^4.4"
         name: PHP ${{ matrix.php }} SF ${{ matrix.symfony_version }} ${{ matrix.composer_flags}}
         env:
             PHP: ${{ matrix.os }}
@@ -45,15 +44,8 @@ jobs:
               run: |
                 composer self-update
                 if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-                if [ "$SYMFONY_VERSION" = "^5.4" ] || [ "$SYMFONY_VERSION" = "^6.1" ] ||  [ "$PHP_VERSION" = "8.0" ] || [ "$PHP_VERSION" = "8.1" ]; then composer remove --dev "friendsofsymfony/oauth-server-bundle" --no-update; fi;
-                if [ "$PHP_VERSION" = "8.1" ] && [ "$SYMFONY_VERSION" = "^6.1" ]; then composer require --dev "phpunit/phpunit:^9.5" --no-update; fi;
-                if [ "$PHP_VERSION" = "8.1" ] && [ "$SYMFONY_VERSION" = "^6.1" ]; then composer require --dev "nikic/php-parser:^4.14" --no-update; fi;
+                if [ "$SYMFONY_VERSION" = "^5.4" ] || [ "$SYMFONY_VERSION" = "^6.3" ] ||  [ "$PHP_VERSION" = "8.0" ] || [ "$PHP_VERSION" = "8.1" ] || [ "$PHP_VERSION" = "8.2" ]; then composer remove --dev "friendsofsymfony/oauth-server-bundle" --no-update; fi;
                 COMPOSER_MEMORY_LIMIT=-1 composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
             - name: Run tests
               run: |
-                php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-            - name: Upload coverage
-              if: ${{ matrix.php == '7.4' }}
-              run: |
-                wget https://scrutinizer-ci.com/ocular.phar
-                php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+                SYMFONY_DEPRECATIONS_HELPER=weak vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         "sensio/framework-extra-bundle": "^3.0|^4.0|^5.0|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.31|^9.5",
+        "symfony/phpunit-bridge": ">=5.4",
         "psr/simple-cache": "^1.0|^2.0",
         "doctrine/cache": "^1.5",
         "psr/cache": "^1.0|^2.0",
-        "predis/predis": "^0.8|^1.1",
+        "predis/predis": "^0.8|^1.1|^2.0",
         "friendsofsymfony/oauth-server-bundle": "^1.5"
     },
     "suggest": {


### PR DESCRIPTION
Stop using directly phpunit and use `symfony/phpunit-bridge` that takes care of choosing the most recent phpunit version based on the installed php version